### PR TITLE
Tweaking the setup_env batch script

### DIFF
--- a/SetupAnaconda/setup_env.bat
+++ b/SetupAnaconda/setup_env.bat
@@ -8,7 +8,7 @@ set EnvironmentPath=%1
 
 :: Create the environment with modules and activate it
 
-call conda create -y -p %EnvironmentPath% tensorflow-gpu pandas opencv jupyter scikit-learn scikit-image matplotlib
+call conda create -y -p %EnvironmentPath% python=3.7 tensorflow pandas opencv jupyter scikit-learn scikit-image matplotlib
 call activate %EnvironmentPath%
 
 call pip install girder-client


### PR DESCRIPTION
I changed the setup_env batch script to specify the python version to use as tensorflow won't install on python installations of version 3.8 or above (for now). Also, changed the tensorflow-gpu package to tensorflow as advised. 